### PR TITLE
Fix vitest hang, wire up Cypress e2e in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,23 @@ jobs:
       - name: Build
         run: npm run build
 
-# Not yet wired up: `npm run test.e2e`. cypress/e2e/test.cy.ts still asserts
-# text ("Tab 1 page") that no longer exists in the app, so it fails regardless
-# of the code under test. Fix that spec first, then add an e2e job that drops
-# CYPRESS_INSTALL_BINARY, starts the app, and points Cypress at it. Note that
-# cypress.config.ts currently sets baseUrl to the dev server's port (5173),
-# so either run `npm run dev` or change the baseUrl to match `npm run preview`.
+  e2e:
+    name: Cypress e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: cypress-io/github-action@v6
+        with:
+          install: false
+          start: npm run dev
+          wait-on: 'http://localhost:5173'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.ts',
+    pool: 'threads',
   }
 })


### PR DESCRIPTION
## Summary
- `vitest` default forks pool hung/timed out spawning workers on this Windows/OneDrive path; switched to `pool: 'threads'` in `vite.config.ts`.
- Ran the rewritten Cypress e2e spec locally against a real dev server for the first time (couldn't before, no binary in the sandbox) — all 3 tests pass. Added an `e2e` job to CI that starts the app and runs Cypress against it.

Full local verification this round: `npm ci`, lint, typecheck, unit tests, build, and Cypress e2e all green.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test.unit`
- [x] `npm run build`
- [x] `npm run dev` + `npx cypress run` (3/3 passing)