### PR TITLE
Update PLAN.md: reflect actual current state

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -9,11 +9,39 @@ roadmap with a concrete backlog.
 
 ---
 
-## 1. Where the project stands today
+## 1. Current state (2026-07-30)
 
-The repo is an Ionic React (Vite) starter with three tab pages and four
-half-finished components. **The app does not currently build.** Findings from a
-full pass over `src/`:
+Phase 0 is fully done, and a slice of Phase 1 landed alongside it (backend
+scaffold + design system got built before the tab/route rework, since they
+were unblocked and independent). Concretely, right now:
+
+| Area | State |
+|---|---|
+| Build / lint / typecheck / unit tests | ✅ Green, in CI on every PR |
+| E2E (Cypress) | ✅ Wired into CI as its own job, 3/3 passing |
+| Design system | ✅ `theme/variables.css` has a real palette (indigo primary, coral "like" accent, teal success, red danger), dark mode auto-follows OS via existing `dark.system.css` |
+| Swipe deck | ✅ `react-tinder-card`-based, full-bleed photo cards, proper z-index stacking. Still shows **placeholder data** (20 identical stock-photo cards) — no real profiles yet |
+| Supabase project | ✅ Created, live, region `ca-central-1` |
+| DB schema | ✅ All 9 tables from §4 applied via `supabase/schema.sql`, RLS enabled on every table, verified reachable (`GET /rest/v1/profiles` → 200) |
+| `.env.local` | ✅ Populated with real `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` |
+| Typed API layer (`src/lib/api/*`) | ❌ Not started — `src/lib/supabase.ts` exports a raw client, nothing wraps it yet, and nothing in the app imports it |
+| Tab/route rework | 🟡 Half done — tab **labels** changed (Discover/Listings/Profile) but **routes are still** `/tab1` `/tab2` `/tab3`, and there's no `/matches` or `/chat/:matchId` yet |
+| Auth | ❌ Not started |
+| Onboarding quiz | ❌ Not started |
+| Matching engine (`src/lib/matching.ts`) | ❌ Not started |
+| Seed data | ❌ Not started — DB has 0 rows |
+| `RoommateFinder.tsx` / `HouseListings.tsx` | 🟡 Original hackathon placeholders, unchanged — still POST to nonexistent mock-API ports, still have the gender/nationality/relationship-status filter set §7 flags for rework |
+
+**Read:** the shell (build, tests, CI, theming, backend plumbing) is solid.
+Nothing in the product's actual value proposition — real profiles, real
+matching, real auth — exists yet. That's exactly Phase 1's remaining scope,
+detailed in §9.
+
+### Starting point (historical — hackathon prototype, before Phase 0)
+
+The repo was an Ionic React (Vite) starter with three tab pages and four
+half-finished components. **The app did not build.** Findings from the
+original full pass over `src/`:
 
 | Area | State | Notes |
 |---|---|---|
@@ -284,10 +312,26 @@ Either way:
 
 ### Design system
 
-`theme/variables.css` is empty, which is why everything looks like the starter.
-Define the palette, radii, spacing, elevation, and card/deck styles once. Dark
-mode is already wired (`dark.system.css`) — honour it. Budget half a day; it's
-the highest visual return in the whole plan.
+✅ Done. `theme/variables.css` has the palette, radii, and shadow tokens;
+`Card.css`/`Card.tsx` use them for the swipe deck. Dark mode inherits for free
+via `dark.system.css` — no extra work needed per-component as long as
+components stay on `--ion-color-*` vars instead of hardcoded hex.
+
+### Integrations — current and planned
+
+Every integration decision here defaults to **free tier, no vendor lock-in
+beyond Supabase**, per the constraint set at project kickoff.
+
+| Integration | Status | Notes |
+|---|---|---|
+| Supabase (Postgres, Auth, Storage, Realtime) | ✅ Live | The only backend. Free tier: 500MB DB, 1GB storage, 50k monthly active users — plenty for a demo/small launch. |
+| Institutional email verification | Not started (Phase 1) | No third-party service needed — Supabase Auth's own email-confirmation flow, gated by a domain allow-list checked in a Postgres trigger or at signup time (`.edu`, `@conestogac.on.ca`, etc.). Zero new integrations. |
+| Push notifications | Not started (Phase 4) | Capacitor's local/push notification plugin + a free tier of Firebase Cloud Messaging (Android) / APNs (iOS) — no paid service required. |
+| Maps / geocoding (commute-time filtering) | Not started (Phase 5 stretch) | Needed only for `max_commute_minutes` beyond straight-line distance. Free options: OpenStreetMap + Nominatim (geocoding) and OSRM (routing) self-hosted or public demo server — avoids a Google Maps API key/billing account. Decide only when Phase 5 is actually reached. |
+| LLM (match explanations, listing normalisation, icebreakers) | Not started (§8, optional layer) | Templated explanations (§5 stage 4) already cover the core value **with zero API cost**. If added later, must go through a server-side Supabase Edge Function — never a client-side key. Model choice deferred; not a blocker for anything in Phase 1–4. |
+
+No other integrations are planned. Payments, SMS, and listing-scraper
+integrations are explicitly out of scope (§2).
 
 ---
 
@@ -408,13 +452,11 @@ Done (as part of the dependency upgrade — the build had to pass to verify it):
       a `manifest.json` that no longer points at two icon files that don't exist.
 - [x] README written.
 
+- [x] E2E job added to CI (`cypress-io/github-action@v6`, runs against
+      `npm run dev`), verified 3/3 passing both locally and in CI.
+
 Still open:
 
-- [ ] Add an e2e job to CI. Deliberately left out for now: the Cypress binary
-      can't be downloaded in every environment, and it's better for CI to
-      reflect real breakage than to go red on infrastructure. The rewritten spec
-      has not been executed — run `npm run dev` and `npm run test.e2e` locally to
-      confirm it passes before wiring it up.
 - [ ] Settle the product name (§13.5), then update `appId`/`appName` before
       generating a native project — the Android package name is painful to change
       once an `android/` project exists.
@@ -434,18 +476,75 @@ and all three are documented in `package.json` under `"comments"`:
 
 ### Phase 1 — Foundation _(2–3 days)_
 
-- Rename tabs to Discover / Listings / Matches / Profile; new routes; delete
-  `ExploreContainer`.
-- Design system in `theme/variables.css` + shared card styles. Light and dark.
-- Supabase project, schema from §4, RLS policies, typed client in `src/lib/api/`.
-- Auth: email + password, magic link, institutional-email verification badge.
-- Onboarding: ~12-question quiz → `lifestyle` + `housing_intent`. Progress bar,
-  resumable, skippable-with-nag.
-- Profile view/edit incl. photo upload to Storage.
-- Seed script: 30–40 realistic fake profiles. **Do this early** — an empty
-  matching app is impossible to develop against or demo.
+Already done: design system, Supabase project + schema + RLS, `ExploreContainer`
+deleted. Tab **labels** already renamed; routes and Matches/Chat tabs are not.
+Remaining work, in dependency order:
 
-**Exit:** you can sign up, build a profile, and see other (seeded) people exist.
+**1. Typed API layer — `src/lib/api/`**
+Nothing should import `src/lib/supabase.ts` directly except this folder.
+- `src/lib/api/client.ts` — re-exports the existing `supabase` singleton.
+- `src/lib/api/auth.ts` — `signUp`, `signIn`, `signOut`, `getSession`,
+  `onAuthStateChange` wrapper.
+- `src/lib/api/profile.ts` — CRUD for `profiles` + `lifestyle` + `housing_intent`.
+- One file per entity as later phases need it (`listings.ts`, `swipes.ts`, etc.)
+  — don't pre-create empty files for entities Phase 1 doesn't touch.
+
+**2. Route rework**
+Replace `/tab1` `/tab2` `/tab3` with `/discover` `/listings` `/matches`
+`/profile` (tab shell) + `/onboarding` and `/chat/:matchId` (pushed, outside
+the tab shell) per §3's IA. Rename `Tab1.tsx`→`DiscoverPage.tsx` etc. — do
+this in the same PR as the route change so file name and route stay aligned,
+not as a later cleanup.
+
+**3. Auth**
+- Email + password via `supabase.auth.signUp` / `signInWithPassword`.
+- On first sign-in, insert a bare `profiles` row (id = auth user id) — this is
+  what makes `/onboarding` vs `/discover` the routing decision (no row yet →
+  onboarding; row exists but `lifestyle` incomplete → resume onboarding; both
+  exist → discover).
+- Institutional email verification: Supabase's built-in email-confirmation
+  link, plus a domain allow-list check (`.edu`, `@conestogac.on.ca`, etc.) at
+  signup — sets `profiles.verified_email`. No new integration (see §6).
+- Magic link is a nice-to-have, not a blocker — password auth alone is enough
+  to exit Phase 1.
+
+**4. Onboarding quiz → `lifestyle` + `housing_intent`**
+Concretely, the ~12 questions and the exact column each fills:
+
+| # | Question (user-facing) | Writes to |
+|---|---|---|
+| 1 | "What's your living situation right now?" (has a place / needs a place / forming a group) | `housing_intent.role` |
+| 2 | Budget range slider | `housing_intent.budget_min/max` |
+| 3 | Move-in window (two date pickers) | `housing_intent.move_in_earliest/latest` |
+| 4 | City + neighbourhoods multi-select | `housing_intent.city`, `neighbourhoods[]` |
+| 5 | "Where do you need to be close to?" (campus/work address → geocoded) | `housing_intent.anchor_lat/lng`, `max_commute_minutes` |
+| 6 | Sleep schedule slider | `lifestyle.sleep_schedule` |
+| 7 | Cleanliness slider | `lifestyle.cleanliness` |
+| 8 | Noise tolerance slider | `lifestyle.noise_tolerance` |
+| 9 | Guest frequency slider | `lifestyle.guest_frequency` |
+| 10 | Sociability slider | `lifestyle.sociability` |
+| 11 | Smoking / cannabis / drinking / pets (one screen, four selects) | `lifestyle.smoking/cannabis/drinking/pets_owned/pets_ok_with` |
+| 12 | "Any dealbreakers?" — pick up to 3 from the above list | `lifestyle.dealbreakers[]` |
+
+Progress bar (12 steps), resumable (each answer saves on step-advance, not
+just at the end — a user closing the tab mid-quiz shouldn't lose progress),
+skippable-with-nag (banner on `/discover` until `lifestyle` + `housing_intent`
+both exist, since the deck is meaningless without them).
+
+**5. Profile view/edit**
+Display + edit everything from onboarding, plus photo upload to Supabase
+Storage (bucket per user, `photos[]` stores storage keys not public URLs —
+resolve to signed/public URL at render time).
+
+**6. Seed script**
+30–40 realistic fake profiles + lifestyle + housing_intent rows, inserted
+directly via the Supabase SQL editor or a one-off script using the
+`service_role` key (server-side only, never shipped to the client). **Do this
+early** — an empty matching app is impossible to develop against or demo, and
+it's what makes Phase 2's deck testable at all.
+
+**Exit:** you can sign up, get routed through onboarding, land on a real
+`/discover` route, and see seeded profiles (not placeholder stock cards).
 
 ### Phase 2 — The core loop _(3–4 days) ← the product_
 
@@ -504,35 +603,35 @@ The scoring function you write for it is the same one that ships later.
 
 ## 10. Backlog
 
-| # | Task | Size | Depends on |
-|---|---|---|---|
-| 1 | Fix `Card.tsx` via `react-tinder-card` | S | — |
-| 2 | Remove Express server from `src/components/` | XS | — |
-| 3 | CI workflow (lint + typecheck + build + unit) | S | — |
-| 4 | App identity, README, manifest | S | — |
-| 5 | Fix broken Cypress spec | XS | — |
-| 6 | Tab/route rework to Discover/Listings/Matches/Profile | M | 1 |
-| 7 | Design system + theme variables | M | — |
-| 8 | Supabase project + schema + RLS | M | — |
-| 9 | Typed API layer `src/lib/api/` | M | 8 |
-| 10 | Auth + institutional email verification | M | 8 |
-| 11 | Onboarding quiz → lifestyle vector | L | 9 |
-| 12 | Profile view/edit + photo upload | M | 9 |
-| 13 | Seed data script (30–40 profiles) | S | 8 |
-| 14 | `matching.ts` — filters, scoring, explanations | L | — |
-| 15 | Unit tests for matching | M | 14 |
-| 16 | Swipe deck UI (+ buttons, keyboard, undo) | L | 1, 7 |
-| 17 | Swipe persistence + mutual match detection | M | 9, 16 |
-| 18 | Matches list | S | 17 |
-| 19 | Realtime chat | L | 17 |
-| 20 | Match expiry + nudges | S | 17 |
-| 21 | Post-a-listing form | L | 9 |
-| 22 | Listing cards in deck + browse view | M | 21 |
-| 23 | Report / block | M | 9 |
-| 24 | Push notifications (Capacitor) | M | 19 |
-| 25 | E2E happy path | M | 19 |
-| 26 | Accessibility pass | M | 16 |
-| 27 | Android build + PWA | M | Phase 4 |
+| # | Task | Size | Depends on | Status |
+|---|---|---|---|---|
+| 1 | Fix `Card.tsx` via `react-tinder-card` | S | — | ✅ |
+| 2 | Remove Express server from `src/components/` | XS | — | ✅ |
+| 3 | CI workflow (lint + typecheck + build + unit + e2e) | S | — | ✅ |
+| 4 | App identity, README, manifest | S | — | ✅ |
+| 5 | Fix broken Cypress spec | XS | — | ✅ |
+| 6 | Tab/route rework to Discover/Listings/Matches/Profile | M | 1 | 🟡 labels only, routes still `/tab1-3` |
+| 7 | Design system + theme variables | M | — | ✅ |
+| 8 | Supabase project + schema + RLS | M | — | ✅ |
+| 9 | Typed API layer `src/lib/api/` | M | 8 | ❌ next up |
+| 10 | Auth + institutional email verification | M | 8 | ❌ |
+| 11 | Onboarding quiz → lifestyle vector | L | 9 | ❌ |
+| 12 | Profile view/edit + photo upload | M | 9 | ❌ |
+| 13 | Seed data script (30–40 profiles) | S | 8 | ❌ |
+| 14 | `matching.ts` — filters, scoring, explanations | L | — | ❌ |
+| 15 | Unit tests for matching | M | 14 | ❌ |
+| 16 | Swipe deck UI (+ buttons, keyboard, undo) | L | 1, 7 | 🟡 deck stacking done, no keyboard/buttons/undo/real data |
+| 17 | Swipe persistence + mutual match detection | M | 9, 16 | ❌ |
+| 18 | Matches list | S | 17 | ❌ |
+| 19 | Realtime chat | L | 17 | ❌ |
+| 20 | Match expiry + nudges | S | 17 | ❌ |
+| 21 | Post-a-listing form | L | 9 | ❌ |
+| 22 | Listing cards in deck + browse view | M | 21 | ❌ |
+| 23 | Report / block | M | 9 | ❌ |
+| 24 | Push notifications (Capacitor) | M | 19 | ❌ |
+| 25 | E2E happy path | M | 19 | 🟡 basic smoke spec exists, not the full critical path |
+| 26 | Accessibility pass | M | 16 | ❌ |
+| 27 | Android build + PWA | M | Phase 4 | ❌ |
 
 ---
 
@@ -570,10 +669,11 @@ just whether the app runs:
 
 1. **Scope of the launch market** — one campus (Conestoga? Waterloo region?) or
    city-wide? Affects cold-start strategy more than any technical decision here.
-2. ~~**Backend**: Supabase or Appwrite?~~ **Decided: Supabase.** Schema +
-   RLS policies live in `supabase/schema.sql`; typed client in
-   `src/lib/supabase.ts`. Still needed: create the actual Supabase project
-   and drop its URL/anon key into `.env.local` (see `.env.example`).
+2. ~~**Backend**: Supabase or Appwrite?~~ **Decided and live.** Schema + RLS
+   policies in `supabase/schema.sql`, applied to a real project; typed client
+   in `src/lib/supabase.ts`; `.env.local` populated and verified reachable.
+   Remaining: the `src/lib/api/` wrapper layer (§9 Phase 1, item 1) — nothing
+   should import `supabase.ts` directly outside that folder.
 3. **Deadline**: is there a demo date driving this, or is it an open-ended
    rebuild? Determines whether we take the weekend-cut path in §9.
 4. **Team size and split** — the phases parallelise cleanly as
@@ -583,5 +683,8 @@ just whether the app runs:
 
 ---
 
-_Last updated: this document tracks the plan, not the implementation. Update it
-when a phase completes or a decision in §6/§13 gets made._
+_Last updated: 2026-07-30. This document tracks the plan, not the
+implementation. Update it when a phase completes or a decision in §6/§13 gets
+made. Current position: Phase 0 done, Phase 1 partially done (design system +
+backend live; auth/routes/onboarding/seed data are the remaining work, in that
+dependency order per §9)._


### PR DESCRIPTION
## Summary
- Doc said Phase 0/Phase 1 backend+design-system work was still pending; it's done. Updated §1 with a real current-state table.
- Added §6 Integrations subsection: current (Supabase) vs planned (institutional email check, push notif, maps/geocoding, LLM), each tagged to a phase, all free-tier.
- Phase 1 in §9 now has the actual remaining breakdown in dependency order: typed API layer → route rework → auth → onboarding (12 questions mapped to exact `lifestyle`/`housing_intent` columns) → profile edit → seed script.
- Backlog table (§10) and open questions (§13) synced to real status.

Docs only, no code changes.