### PR TITLE
Add typed Supabase API layer

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,29 @@
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { supabase } from './client';
+
+export async function signUp(email: string, password: string) {
+  const { data, error } = await supabase.auth.signUp({ email, password });
+  if (error) throw error;
+  return data;
+}
+
+export async function signIn(email: string, password: string) {
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw error;
+  return data;
+}
+
+export async function signOut() {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+}
+
+export async function getSession() {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  return data.session;
+}
+
+export function onAuthStateChange(callback: (event: AuthChangeEvent, session: Session | null) => void) {
+  return supabase.auth.onAuthStateChange(callback);
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,1 @@
+export { supabase } from '../supabase';

--- a/src/lib/api/profile.test.ts
+++ b/src/lib/api/profile.test.ts
@@ -1,0 +1,30 @@
+const { fromMock } = vi.hoisted(() => ({ fromMock: vi.fn() }));
+vi.mock('./client', () => ({ supabase: { from: fromMock } }));
+
+import { getProfile, upsertProfile } from './profile';
+
+function queryChain(result: { data: unknown; error: unknown }) {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () => Promise.resolve(result),
+    upsert: () => chain,
+    single: () => Promise.resolve(result),
+  };
+  return chain;
+}
+
+test('getProfile returns the row on success', async () => {
+  fromMock.mockReturnValue(queryChain({ data: { id: '1' }, error: null }));
+  await expect(getProfile('1')).resolves.toEqual({ id: '1' });
+});
+
+test('getProfile throws on a Supabase error instead of swallowing it', async () => {
+  fromMock.mockReturnValue(queryChain({ data: null, error: new Error('boom') }));
+  await expect(getProfile('1')).rejects.toThrow('boom');
+});
+
+test('upsertProfile throws on a Supabase error instead of swallowing it', async () => {
+  fromMock.mockReturnValue(queryChain({ data: null, error: new Error('boom') }));
+  await expect(upsertProfile({ id: '1', display_name: 'A' } as never)).rejects.toThrow('boom');
+});

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -1,0 +1,105 @@
+import { supabase } from './client';
+
+export type Occupation = 'student' | 'working' | 'both' | 'other';
+
+export interface Profile {
+  id: string;
+  display_name: string;
+  birthdate: string;
+  pronouns: string | null;
+  bio: string | null;
+  photos: string[];
+  occupation: Occupation;
+  school_or_employer: string | null;
+  verified_email: boolean;
+  last_active_at: string;
+  created_at: string;
+}
+
+export type SmokingLevel = 'none' | 'outdoor_ok' | 'indoor';
+export type DrinkingLevel = 'none' | 'social' | 'frequent';
+export type PetsOwned = 'none' | 'cat' | 'dog' | 'other';
+export type PetsOkWith = 'any' | 'cats_only' | 'dogs_only' | 'none' | 'allergic';
+export type KitchenSharing = 'share_everything' | 'share_space_not_food' | 'separate';
+
+export interface Lifestyle {
+  profile_id: string;
+  sleep_schedule: number;
+  cleanliness: number;
+  noise_tolerance: number;
+  guest_frequency: number;
+  sociability: number;
+  wfh_days: number;
+  smoking: SmokingLevel;
+  cannabis: SmokingLevel;
+  drinking: DrinkingLevel;
+  pets_owned: PetsOwned;
+  pets_ok_with: PetsOkWith;
+  kitchen_sharing: KitchenSharing;
+  dealbreakers: string[];
+}
+
+export type HousingRole = 'has_place' | 'needs_place' | 'forming_group';
+
+export interface HousingIntent {
+  profile_id: string;
+  role: HousingRole;
+  budget_min: number;
+  budget_max: number;
+  move_in_earliest: string;
+  move_in_latest: string;
+  lease_months: number | null;
+  city: string;
+  neighbourhoods: string[];
+  anchor_lat: number | null;
+  anchor_lng: number | null;
+  max_commute_minutes: number | null;
+}
+
+export async function getProfile(id: string): Promise<Profile | null> {
+  const { data, error } = await supabase.from('profiles').select('*').eq('id', id).maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertProfile(profile: Partial<Profile> & { id: string }): Promise<Profile> {
+  const { data, error } = await supabase.from('profiles').upsert(profile).select().single();
+  if (error) throw error;
+  return data;
+}
+
+export async function getLifestyle(profileId: string): Promise<Lifestyle | null> {
+  const { data, error } = await supabase
+    .from('lifestyle')
+    .select('*')
+    .eq('profile_id', profileId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertLifestyle(
+  lifestyle: Partial<Lifestyle> & { profile_id: string }
+): Promise<Lifestyle> {
+  const { data, error } = await supabase.from('lifestyle').upsert(lifestyle).select().single();
+  if (error) throw error;
+  return data;
+}
+
+export async function getHousingIntent(profileId: string): Promise<HousingIntent | null> {
+  const { data, error } = await supabase
+    .from('housing_intent')
+    .select('*')
+    .eq('profile_id', profileId)
+    .maybeSingle();
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertHousingIntent(
+  intent: Partial<HousingIntent> & { profile_id: string }
+): Promise<HousingIntent> {
+  const { data, error } = await supabase.from('housing_intent').upsert(intent).select().single();
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## Summary
- `src/lib/api/client.ts` — single re-export point for the Supabase singleton.
- `src/lib/api/auth.ts` — signUp/signIn/signOut/getSession/onAuthStateChange wrappers.
- `src/lib/api/profile.ts` — typed CRUD for `profiles`, `lifestyle`, `housing_intent` (types mirror `supabase/schema.sql` columns/enums exactly).
- `src/lib/api/profile.test.ts` — mocks the client to confirm Supabase errors throw instead of getting swallowed.

Nothing wires this into any component yet — that starts with the route rework / auth screens next (Phase 1, docs/PLAN.md §9).

## Test plan
- [x] lint / typecheck / unit tests / build all green